### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 01.04.2025
+
 ### Added
 
 - Added `tt` restart and status to the command palette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tarantool",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tarantool",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "devDependencies": {
         "@octokit/core": "^5",
         "@types/command-exists": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "tarantool",
   "displayName": "Tarantool",
   "description": "Develop Tarantool applications with ease",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "icon": "res/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/georgiy-belyanin/tarantool-vscode"
+    "url": "https://github.com/tarantool/tarantool-vscode"
   },
   "publisher": "tarantool",
   "engines": {


### PR DESCRIPTION
This patch adds 0.1.0 header to the changelog and is going to be released as 0.1.0.

Also, this repository has migrated to tarantool/tarantool-vscode.