### PR TITLE
Setup marketplace extension publish on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
-name: Build
+name: Build & publish
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "*.*.*"
   pull_request:
 
 jobs:
@@ -28,3 +32,13 @@ jobs:
       with:
         name: Tarantool VSCode
         path: ${{ github.workspace }}/tarantool-vscode.vsix
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: success() && startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+      - run: npx vsce publish --packagePath $(find tarantool-vscode* -iname "*.vsix")
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
This patch adds CD via GitHub actions. When the version tag is pushed the action is automatically published on VS Code marketplace.

It also makes the build CI run only on push in main to remove duplicating pull request runs caused by pushing in non-main branches.