### PR TITLE
Fix wrong artifact path in CI publish job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
-        name: Tarantool VSCode
+        name: tarantool-vscode
         path: ${{ github.workspace }}/tarantool-vscode.vsix
 
   publish:


### PR DESCRIPTION
This patch fixes a wrong path in publish CI job. Turned out the artifacts are downloaded to `./<artifact-name>/<artifact>` and not in `./<artifact>` as it's been expected. Thus, the artifact has been downloaded in the unexpected directory.

Let's rename the artifact name to `tarantool-vscode` for the job to seek in the same directory name as the `.vsix` name.