### PR TITLE
Downgrade minimum VS Code version to 1.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Now the minimum required VS Code version is 1.88.0 making it possible to
+  install the extension to the apps based on the older version of VS Code like
+  Cursor.
+
 ## [0.1.1] - 07.04.2025
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/command-exists": "^1.2.3",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
-        "@types/vscode": "^1.98.0",
+        "@types/vscode": "^1.88.0",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
         "@vscode/test-cli": "^0.0.10",
@@ -26,7 +26,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.98.0"
+        "vscode": "^1.88.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "publisher": "tarantool",
   "engines": {
-    "vscode": "^1.98.0"
+    "vscode": "^1.88.0"
   },
   "categories": [
     "Programming Languages",
@@ -91,7 +91,7 @@
     "@types/command-exists": "^1.2.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
-    "@types/vscode": "^1.98.0",
+    "@types/vscode": "^1.88.0",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
     "@vscode/test-cli": "^0.0.10",


### PR DESCRIPTION
This patch downgrades the required VS Code version to 1.88.0. It with it to be a problem when I tried to install the extension into Cursor having 1.96.0 version instead of the required 1.98.0. There shouldn't be any problem with downgrading the minimum version to the one released about one year ago.