### PR TITLE
Release 0.1.2 fixup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tarantool",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tarantool",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "@octokit/core": "^5",
         "@types/command-exists": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tarantool",
   "displayName": "Tarantool",
   "description": "Develop Tarantool applications with ease",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "icon": "res/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Commit cc0a8c1d3 ('Release 0.1.2') has been messed up due to missing release number bump in package meta. This patch fixes it and is going to be tagged as 0.1.2.