### PR TITLE
Set up language server configuration automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Now the extension automatically setups Tarantool annotations without need to
+  explicitly execute any commands like `initialize VS Code extension`.
+
 ## [0.1.3] - 14.04.2025
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@octokit/core": "^5",
         "@types/command-exists": "^1.2.3",
+        "@types/lodash": "^4.17.16",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
         "@types/vscode": "^1.88.0",
@@ -20,6 +21,7 @@
         "command-exists": "^1.2.9",
         "copy-webpack-plugin": "^13.0.0",
         "eslint": "^9.23.0",
+        "lodash": "^4.17.21",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.2",
         "webpack": "^5.98.0",
@@ -638,6 +640,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3000,6 +3009,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "linter",
     "snippets"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onLanguage:lua"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -89,6 +91,7 @@
   "devDependencies": {
     "@octokit/core": "^5",
     "@types/command-exists": "^1.2.3",
+    "@types/lodash": "^4.17.16",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
     "@types/vscode": "^1.88.0",
@@ -99,6 +102,7 @@
     "command-exists": "^1.2.9",
     "copy-webpack-plugin": "^13.0.0",
     "eslint": "^9.23.0",
+    "lodash": "^4.17.21",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.2",
     "webpack": "^5.98.0",


### PR DESCRIPTION
Now, Tarantool VS Code extension automatically setups annotations on
system level by providing the default configuration within
`$HOME/.emmyrc.json`. This requires [VSCode Emmylua 0.9.18](https://github.com/EmmyLua/VSCode-EmmyLua/tree/0.9.18).

Closes #12
