### PR TITLE
Set up provided rocks type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `box.space.*:format()` documentation and annotations.
 - `box.schema.role` and `box.schema.user` documentation and type annotations.
 - Annotations on a few supplementary spaces like `box.schema._cluster`.
+- Setting up provided Rock type annotations (currently only `vshard` is done).
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,10 @@ import * as vscode from 'vscode';
 import * as tt from './tt';
 import * as fs from 'fs';
 
-const annotationsPaths = [ __dirname + "/Library" ];
+const annotationsPaths = [
+	__dirname + "/Library",
+	__dirname + "/Rocks"
+];
 const emmyrc = {
 	"runtime": {
 		"version": "LuaJIT"


### PR DESCRIPTION
This patch makes the extension not only supply the builtin Tarantool
modules but the provided rocks type annotations. Currently only `vshard`
is added.
