### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 14.04.2025
+
 ### Added
 
 - Builtin `buffer` module definitions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tarantool",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tarantool",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "devDependencies": {
         "@octokit/core": "^5",
         "@types/command-exists": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tarantool",
   "displayName": "Tarantool",
   "description": "Develop Tarantool applications with ease",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "icon": "res/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This patch adds 0.1.3 header to the changelog and is going to be
released as 0.1.3.
