### PR TITLE
Add option for providing a path to TT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A `tarantool.ttPath` configuration option can now be used to specify a path to
+  TT utility if it's not available in the `$PATH`.
+
 ### Changed
 
 - Now the extension automatically setups Tarantool annotations without need to

--- a/package.json
+++ b/package.json
@@ -75,7 +75,17 @@
         ],
         "url": "https://download.tarantool.org/tarantool/schema/config.schema.json"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Tarantool",
+      "properties": {
+        "tarantool.ttPath": {
+           "type": "string",
+           "default": "tt",
+           "markdownDescription": "Specifies a path to the TT executable, defaults to the one available in the `$PATH`."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,6 @@ async function initGlobalEmmyrc() {
 	const existingEmmyrc = JSON.parse(f);
 	const upToDate = _.isMatch(existingEmmyrc, emmyrc);
 	if (upToDate) {
-		vscode.window.showInformationMessage(`${globalEmmyrcPath} is up to date`);
 		return;
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as tt from './tt';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as _ from 'lodash';
+import * as utils from './utils';
 
 const annotationsPaths = [
 	__dirname + "/Library",
@@ -43,21 +44,12 @@ async function initGlobalEmmyrc() {
 }
 
 async function initVs() {
-	const file = vscode.window.activeTextEditor?.document.uri.fsPath;
+	const wsPath = utils.fetchWsFolder({ showWarning: true })?.uri.fsPath;
+	if (!wsPath) {
+		return;
+	}
 
 	const wsedit = new vscode.WorkspaceEdit();
-	const wsFolders = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath);
-	if (!wsFolders) {
-		vscode.window.showWarningMessage('Please, open a project before running this command');
-		return;
-	}
-	
-	const wsPath = file ? wsFolders.find((folder) => file.startsWith(folder)) : wsFolders.at(0);
-	if (!wsPath) {
-		vscode.window.showWarningMessage('Please, open at least one folder within the workspace');
-		return;
-	}
-
 	const filePath = vscode.Uri.file(`${wsPath}/${emmyrcFile}`);
 	if (fs.existsSync(filePath.fsPath)) {
 		const yes = "Yes";

--- a/src/tt.ts
+++ b/src/tt.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import commandExists = require('command-exists');
 import { Octokit } from '@octokit/core';
+import * as utils from './utils';
 
 const octokit = new Octokit();
 
@@ -15,12 +16,15 @@ function getTerminal(): vscode.Terminal {
 
 function cmd(body: string) {
 	return async () => {
-		const tt = 'tt';
+		const wsFolder = utils.fetchWsFolder();
+		const config = vscode.workspace.getConfiguration(undefined, wsFolder);
+		const tt = config.get<string>('tarantool.ttPath') || 'tt';
+
 		commandExists(`${tt}`).then(() => {
 			const t = getTerminal();
 			t.sendText(`${tt} ${body}`);
 		}).catch(function () {
-			vscode.window.showErrorMessage('TT is not installed');
+			vscode.window.showErrorMessage('TT is not available. Install it or provide a path to it explicitly in the Tarantool plugin configuration.');
 		});
 	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export function fetchWsFolder(opts?: { showWarning?: boolean }): vscode.WorkspaceFolder | null {
+	const file = vscode.window.activeTextEditor?.document.uri.fsPath;
+
+	const wsFolders = vscode.workspace.workspaceFolders;
+	if (!wsFolders) {
+		if (opts?.showWarning) {
+			vscode.window.showWarningMessage('Please, open a project before running this command');
+		}
+		return null;
+	}
+	
+	const wsFolder = file ? wsFolders.find((folder) => file.startsWith(folder.uri.fsPath)) : wsFolders.at(0);
+	if (!wsFolder) {
+		if (opts?.showWarning) {
+			vscode.window.showWarningMessage('Please, open at least one folder within the workspace');
+		}
+		return null;
+	}
+
+	return wsFolder;
+}


### PR DESCRIPTION
The main purpose of the patchset is to add a way to supply a path to TT utility.

The first patch adds the `tarantool.ttPath` option itself.

The later one makes is a small change making the extension not issue a message
on actual config that's been added in #14

Close #20
