### PR TITLE
Issue warn if EmmyLua is old for global config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/lodash": "^4.17.16",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
+        "@types/semver": "^7.7.0",
         "@types/vscode": "^1.88.0",
         "@typescript-eslint/eslint-plugin": "^8.28.0",
         "@typescript-eslint/parser": "^8.28.0",
@@ -22,6 +23,7 @@
         "copy-webpack-plugin": "^13.0.0",
         "eslint": "^9.23.0",
         "lodash": "^4.17.21",
+        "semver": "^7.7.2",
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.2",
         "webpack": "^5.98.0",
@@ -666,6 +668,13 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.98.0",
@@ -4028,9 +4037,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -80,9 +80,9 @@
       "title": "Tarantool",
       "properties": {
         "tarantool.ttPath": {
-           "type": "string",
-           "default": "tt",
-           "markdownDescription": "Specifies a path to the TT executable, defaults to the one available in the `$PATH`."
+          "type": "string",
+          "default": "tt",
+          "markdownDescription": "Specifies a path to the TT executable, defaults to the one available in the `$PATH`."
         }
       }
     }
@@ -104,6 +104,7 @@
     "@types/lodash": "^4.17.16",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
+    "@types/semver": "^7.7.0",
     "@types/vscode": "^1.88.0",
     "@typescript-eslint/eslint-plugin": "^8.28.0",
     "@typescript-eslint/parser": "^8.28.0",
@@ -113,6 +114,7 @@
     "copy-webpack-plugin": "^13.0.0",
     "eslint": "^9.23.0",
     "lodash": "^4.17.21",
+    "semver": "^7.7.2",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.2",
     "webpack": "^5.98.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as tt from './tt';
 import * as fs from 'fs';
 import * as _ from 'lodash';
+import * as semver from 'semver';
 import * as utils from './utils';
 
 const annotationsPaths = [
@@ -19,8 +20,16 @@ const emmyrc = {
 const emmyrcFile = '.emmyrc.json';
 const globalEmmyrcKey = 'emmylua.misc.globalConfigPath';
 const globalEmmyrcPath = __dirname + `/${emmyrcFile}`;
+const globalConfigEmmyluaVersion = '0.9.19';
 
 async function initGlobalEmmyrc() {
+	const emmyLua = vscode.extensions.getExtension('tangzx.emmylua');
+	const emmyLuaVersion = emmyLua?.packageJSON.version;
+	if (!semver.gte(emmyLuaVersion, globalConfigEmmyluaVersion)) {
+		vscode.window.showWarningMessage(`Unable to set up Tarantool extension globally due to the old version of the EmmyLua extension: current version is ${emmyLuaVersion}, required version is ${globalConfigEmmyluaVersion}. Consider updating EmmyLua using marketplace or run a 'Tarantool: Initialize VS Code extension...' command having your Tarantool project opened`);
+		return;
+	}
+
 	const config = vscode.workspace.getConfiguration(undefined, null);
 	const configuredGlobalEmmyrcPath = config.get(globalEmmyrcKey);
 


### PR DESCRIPTION
This patch makes the extension issue a warning if the EmmyLua dependency
is old and doesn't support global configuration feature added in
0.9.19.
