### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,10 +99,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed duplicating `tarantool-emmylua` and GitHub CI from the bundle.
 
-## [0.0.1] - 28.03.2025
+## 0.0.1 - 28.03.2025
 
 ### Added
 
 - Added support for EmmyLua LSP and Tarantool-specific annottations.
 - Added jsonschema checks for Tarantool cluster configuration.
 - Added `tt` start and stop commands to the command palette.
+
+[unreleased]: https://github.com/tarantool/tarantool-vscode/compare/0.1.3...HEAD
+[0.1.3]: https://github.com/tarantool/tarantool-vscode/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/tarantool/tarantool-vscode/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/tarantool/tarantool-vscode/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/tarantool/tarantool-vscode/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 28.05.2025
+
 ### Added
 
 - A `tarantool.ttPath` configuration option can now be used to specify a path to
@@ -107,7 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added jsonschema checks for Tarantool cluster configuration.
 - Added `tt` start and stop commands to the command palette.
 
-[unreleased]: https://github.com/tarantool/tarantool-vscode/compare/0.1.3...HEAD
+[unreleased]: https://github.com/tarantool/tarantool-vscode/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/tarantool/tarantool-vscode/compare/0.1.3...0.2.0
 [0.1.3]: https://github.com/tarantool/tarantool-vscode/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/tarantool/tarantool-vscode/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/tarantool/tarantool-vscode/compare/0.1.0...0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tarantool",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tarantool",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "devDependencies": {
         "@octokit/core": "^5",
         "@types/command-exists": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tarantool",
   "displayName": "Tarantool",
   "description": "Develop Tarantool applications with ease",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "icon": "res/icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The first patch adds links to compare the releases to the changelog
as it should be done in the keep-a-changelog format.

The later patch adds 0.2.0 header to the changelog and is going to be
released as 0.2.0.
